### PR TITLE
fix: publish image to right owner repo

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -26,5 +26,5 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/the-gophers/go-action:${{ env.RELEASE_VERSION }}
-            ghcr.io/the-gophers/go-action:latest
+            ghcr.io/${{ github.repository_owner }}/go-action:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ github.repository_owner }}/go-action:latest


### PR DESCRIPTION
# Context

I noticed the image publish is defaulting to the-gopher owner rather than the repository owner, which triggers 403 error at publishing the image.

This PR fixes the image publish to publish to the owner repo instead.
